### PR TITLE
A simplification tactic for Z-module equations, specific to Z

### DIFF
--- a/ac_simplifier/elpi/theories/Tactic.v
+++ b/ac_simplifier/elpi/theories/Tactic.v
@@ -3,18 +3,10 @@ From elpi Require Import elpi.
 From AC Require Import AC.
 
 (******************************************************************************)
-(* The Z_zmodule tactic                                                       *)
+(* Tactics specific to Z                                                      *)
 (******************************************************************************)
 
-Ltac Z_zmodule_reflection VM ZE1 ZE2 :=
-  apply (@ZM_correct_Z VM ZE1 ZE2); [vm_compute; reflexivity].
-
-Elpi Tactic Z_zmodule.
-Elpi Accumulate lp:{{
-
-pred mem o:list term, o:term, o:term.
-mem [X|_] X {{ O }} :- !.
-mem [_|XS] X {{ S lp:N }} :- !, mem XS X N.
+Elpi Db Z_reify lp:{{
 
 pred quote i:term, o:term, o:list term.
 quote {{ Z0 }} {{ AGO }} _ :- !.
@@ -23,9 +15,24 @@ quote {{ Z.add lp:In1 lp:In2 }} {{ AGAdd lp:Out1 lp:Out2 }} VM :- !,
   quote In1 Out1 VM, quote In2 Out2 VM.
 quote In {{ AGX lp:N }} VM :- !, mem VM In N.
 
+pred mem o:list term, o:term, o:term.
+mem [X|_] X {{ O }} :- !.
+mem [_|XS] X {{ S lp:N }} :- !, mem XS X N.
+
 pred list-constant o:term, o:list term, o:term.
 list-constant T [] {{ @nil lp:T }} :- !.
 list-constant T [X|XS] {{ @cons lp:T lp:X lp:XS' }} :- list-constant T XS XS'.
+
+}}.
+
+(* The Z_zmodule tactic *)
+
+Ltac Z_zmodule_reflection VM ZE1 ZE2 :=
+  apply (@ZM_correct_Z VM ZE1 ZE2); [vm_compute; reflexivity].
+
+Elpi Tactic Z_zmodule.
+Elpi Accumulate Db Z_reify.
+Elpi Accumulate lp:{{
 
 pred solve i:goal, o:list sealed-goal.
 solve (goal _ _ {{ @eq Z lp:T1 lp:T2 }} _ _ as Goal) GS :- !,
@@ -45,3 +52,48 @@ zmod-reflection _ _ _ _ _ :-
 Elpi Typecheck.
 
 Tactic Notation "Z_zmodule" := (elpi Z_zmodule).
+
+(* The Z_zmodule_simplify tactic *)
+
+Ltac Z_zmodule_simplify_reflection VM ZE1 ZE2 :=
+  let zero := fresh "zero" in
+  let add := fresh "add" in
+  let vm := fresh "vm" in
+  let zeroE := fresh "zeroE" in
+  let addE := fresh "addE" in
+  let vmE := fresh "vmE" in
+  let norm := fresh "norm" in
+  apply (@ZMsimpl_correct_Z VM ZE1 ZE2);
+  intros zero add vm zeroE addE vmE norm;
+  vm_compute in norm; compute;
+  rewrite zeroE, addE, vmE; clear zero add vm zeroE addE vmE norm.
+
+Elpi Tactic Z_zmodule_simplify.
+Elpi Accumulate Db Z_reify.
+Elpi Accumulate lp:{{
+
+pred solve i:goal, o:list sealed-goal.
+solve (goal _ _ {{ @eq Z lp:T1 lp:T2 }} _ _ as Goal) GS :- !,
+  quote T1 ZE1 VM, !,
+  quote T2 ZE2 VM, !,
+  list-constant {{ Z }} VM VM', !,
+  zmod-simpl-reflection VM' ZE1 ZE2 Goal GS.
+solve _ _ :- coq.ltac.fail 0 "The goal is not an equation".
+
+pred zmod-simpl-reflection i:term, i:term, i:term, i:goal, o:list sealed-goal.
+zmod-simpl-reflection VM ZE1 ZE2 G GS :-
+  coq.ltac.call "Z_zmodule_simplify_reflection" [trm VM, trm ZE1, trm ZE2] G GS.
+zmod-simpl-reflection _ _ _ _ _ :-
+  coq.ltac.fail 0 "Reflection failed".
+
+}}.
+Elpi Typecheck.
+
+Tactic Notation "Z_zmodule_simplify" := (elpi Z_zmodule_simplify).
+
+Goal forall x y y' z, y = y' -> (x + y + - z + y = x + - z + y + y')%Z.
+Proof.
+intros x y y' z Hy.
+Z_zmodule_simplify.
+exact Hy.
+Qed.

--- a/ac_simplifier/elpi/theories/Tests.v
+++ b/ac_simplifier/elpi/theories/Tests.v
@@ -6,3 +6,9 @@ Proof.
 intros x y z.
 Z_zmodule.
 Qed.
+
+Goal forall x y y' z, y = y' -> (x + y + - z + y = x + - z + y + y')%Z.
+Proof.
+intros x y y' z Hy.
+Z_zmodule_simplify; exact Hy.
+Qed.


### PR DESCRIPTION
This PR implements the `Z_zmodule_simplify` tactic. For example, it turns a goal of the form
```coq
(x + y + - z + y)%Z = (x + - z + y + y')%Z
```
into
```coq
y = y'.
```

This kind of reflexive tactic leaving a proof obligation needs to simplify the obligation carefully. I'm not sure whether the current implementation is the best way to do so.